### PR TITLE
Allowed future majors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,17 +29,17 @@
         "php": ">=8.0"
     },
     "require-dev": {
-        "codeception/codeception": "^5.1",
-        "codeception/module-asserts": "^3.0",
-        "codeception/module-db": "^3.1",
-        "codeception/module-phpbrowser": "^3.0",
-        "friendsofphp/php-cs-fixer": "^3.49",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "psr/clock": "^1.0",
-        "psr/log": "^3.0",
-        "rockylars/package-files": "^1.0",
-        "spaze/phpstan-disallowed-calls": "^3.1",
-        "thecodingmachine/phpstan-safe-rule": "^1.2"
+        "codeception/codeception": ">=5.1",
+        "codeception/module-asserts": ">=3.0",
+        "codeception/module-db": ">=3.1",
+        "codeception/module-phpbrowser": ">=3.0",
+        "friendsofphp/php-cs-fixer": ">=3.49",
+        "phpstan/phpstan": ">=1.10",
+        "phpstan/phpstan-deprecation-rules": ">=1.1",
+        "psr/clock": ">=1.0",
+        "psr/log": ">=3.0",
+        "rockylars/package-files": ">=1.0",
+        "spaze/phpstan-disallowed-calls": ">=3.1",
+        "thecodingmachine/phpstan-safe-rule": ">=1.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5c9cb1c40e77e08c3228028dca90158",
+    "content-hash": "811cdfe7f5dd1767b39bdd9f515e07e1",
     "packages": [],
     "packages-dev": [
         {
@@ -301,30 +301,30 @@
         },
         {
             "name": "codeception/lib-web",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/lib-web.git",
-                "reference": "cea9d53c9cd665498632acc417c9a96bff7eb2b0"
+                "reference": "01ff7f9ed8760ba0b0805a0b3a843b4e74165a60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/lib-web/zipball/cea9d53c9cd665498632acc417c9a96bff7eb2b0",
-                "reference": "cea9d53c9cd665498632acc417c9a96bff7eb2b0",
+                "url": "https://api.github.com/repos/Codeception/lib-web/zipball/01ff7f9ed8760ba0b0805a0b3a843b4e74165a60",
+                "reference": "01ff7f9ed8760ba0b0805a0b3a843b4e74165a60",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "guzzlehttp/psr7": "^2.0",
                 "php": "^8.0",
+                "phpunit/phpunit": "^9.5 | ^10.0 | ^11.0",
                 "symfony/css-selector": ">=4.4.24 <8.0"
             },
             "conflict": {
                 "codeception/codeception": "<5.0.0-alpha3"
             },
             "require-dev": {
-                "php-webdriver/webdriver": "^1.12",
-                "phpunit/phpunit": "^9.5 | ^10.0"
+                "php-webdriver/webdriver": "^1.12"
             },
             "type": "library",
             "autoload": {
@@ -348,9 +348,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeception/lib-web/issues",
-                "source": "https://github.com/Codeception/lib-web/tree/1.0.5"
+                "source": "https://github.com/Codeception/lib-web/tree/1.0.6"
             },
-            "time": "2024-01-13T11:54:18+00:00"
+            "time": "2024-02-06T20:50:08+00:00"
         },
         {
             "name": "codeception/module-asserts",


### PR DESCRIPTION
Will make development a bit easier. We currently set a baseline for what we needed to make it work, but we can dip down to any version lower. This is just to make going up a bit easier.

This only updates dev, does not require a new release.